### PR TITLE
Audio segments speed fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ ndg-httpsclient
 pyasn1
 urllib3
 ffprobe
+audiostretchy


### PR DESCRIPTION
Применила функцию stretch_audio из библиотеки audiostretchy для ускорения сегментов аудио без изменения тембра голоса
Что происходит в коде:
- сохраняю сегмент во временный wav файл
- в функцию stretch_audio передаю путь до сохраненного сегмента, путь куда сохранить ускоренный сегмент (output.wav) и ratio
- достаю из сохраненного файла ускоренный сегмент